### PR TITLE
Release/0.1.1

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -1,3 +1,4 @@
+dist: trusty
 language: scala
 services:
   - docker

--- a/.travis/deploy_template.sh
+++ b/.travis/deploy_template.sh
@@ -15,6 +15,7 @@ if [[ "${tag}" = *"${project_version}" ]]; then
       --tempLocation=gs://sp-hosted-assets/tmp \
       --autoscalingAlgorithm=THROUGHPUT_BASED \
       --numWorkers=1 \
+      --numShards=1 \
       --diskSizeGb=30 \
       --workerMachineType=n1-standard-1"
 else

--- a/CHANGELOG
+++ b/CHANGELOG
@@ -1,3 +1,14 @@
+Version 0.1.1 (2019-12-)
+--------------------------
+Set default number of shards to be managed by runner (#27)
+Bump mockito to 2.28.2 (#25)
+Bump slf4j to 1.7.29 (#23)
+Bump scalatest to 3.0.8 (#22)
+Remove beam dependecy (#21)
+Bump scala to 2.12.10 (#20)
+Extend copyright to 2019 (#26)
+Travis distribution to Trusty (#29)
+
 Version 0.1.0 (2018-11-23)
 --------------------------
 Initial version

--- a/LICENSE-2.0.txt
+++ b/LICENSE-2.0.txt
@@ -187,7 +187,7 @@
       same "printed page" as the copyright notice for easier
       identification within third-party archives.
 
-   Copyright [2018-2018] [Snowplow Analytics Ltd.]
+   Copyright 2018-2019 Snowplow Analytics Ltd.
 
    Licensed under the Apache License, Version 2.0 (the "License");
    you may not use this file except in compliance with the License.

--- a/README.md
+++ b/README.md
@@ -172,7 +172,7 @@ sbt repl/run
 
 ## Copyright and license
 
-Copyright 2018-2018 Snowplow Analytics Ltd.
+Copyright 2018-2019 Snowplow Analytics Ltd.
 
 Licensed under the [Apache License, Version 2.0][license] (the "License");
 you may not use this software except in compliance with the License.

--- a/build.sbt
+++ b/build.sbt
@@ -3,7 +3,7 @@ import Keys._
 
 val scioVersion = "0.7.4"
 val scalaMacrosVersion = "2.1.1"
-val slf4jVersion = "1.7.25"
+val slf4jVersion = "1.7.29"
 val scalatestVersion = "3.0.8"
 val mockitoVersion = "2.23.0"
 

--- a/build.sbt
+++ b/build.sbt
@@ -1,8 +1,8 @@
 import sbt._
 import Keys._
 
-val scioVersion = "0.6.1"
 val beamVersion = "2.6.0"
+val scioVersion = "0.7.4"
 val scalaMacrosVersion = "2.1.1"
 val slf4jVersion = "1.7.25"
 val scalatestVersion = "3.0.5"

--- a/build.sbt
+++ b/build.sbt
@@ -1,7 +1,6 @@
 import sbt._
 import Keys._
 
-val beamVersion = "2.6.0"
 val scioVersion = "0.7.4"
 val scalaMacrosVersion = "2.1.1"
 val slf4jVersion = "1.7.25"
@@ -57,7 +56,6 @@ lazy val root: Project = project
     libraryDependencies ++= Seq(
       "com.spotify" %% "scio-core" % scioVersion,
       "com.spotify" %% "scio-test" % scioVersion % Test,
-      "org.apache.beam" % "beam-runners-google-cloud-dataflow-java" % beamVersion,
       "org.slf4j" % "slf4j-simple" % slf4jVersion,
       "org.scalatest" %% "scalatest" % scalatestVersion % Test,
       "org.mockito" % "mockito-core" % mockitoVersion % Test

--- a/build.sbt
+++ b/build.sbt
@@ -5,7 +5,7 @@ val scioVersion = "0.7.4"
 val scalaMacrosVersion = "2.1.1"
 val slf4jVersion = "1.7.29"
 val scalatestVersion = "3.0.8"
-val mockitoVersion = "2.23.0"
+val mockitoVersion = "2.28.2"
 
 lazy val compilerOptions = Seq(
   "-target:jvm-1.8",

--- a/build.sbt
+++ b/build.sbt
@@ -4,7 +4,7 @@ import Keys._
 val scioVersion = "0.7.4"
 val scalaMacrosVersion = "2.1.1"
 val slf4jVersion = "1.7.25"
-val scalatestVersion = "3.0.5"
+val scalatestVersion = "3.0.8"
 val mockitoVersion = "2.23.0"
 
 lazy val compilerOptions = Seq(

--- a/build.sbt
+++ b/build.sbt
@@ -27,7 +27,7 @@ lazy val compilerOptions = Seq(
 lazy val commonSettings = Defaults.coreDefaultSettings ++ Seq(
   organization := "com.snowplowanalytics",
   version := "0.1.0",
-  scalaVersion := "2.12.7",
+  scalaVersion := "2.12.10",
   scalacOptions ++= compilerOptions,
   javacOptions ++= Seq("-source", "1.8", "-target", "1.8")
 )

--- a/build.sbt
+++ b/build.sbt
@@ -25,7 +25,7 @@ lazy val compilerOptions = Seq(
 
 lazy val commonSettings = Defaults.coreDefaultSettings ++ Seq(
   organization := "com.snowplowanalytics",
-  version := "0.1.0",
+  version := "0.1.1",
   scalaVersion := "2.12.10",
   scalacOptions ++= compilerOptions,
   javacOptions ++= Seq("-source", "1.8", "-target", "1.8")

--- a/src/main/scala/com/snowplowanalytics/storage/googlecloudstorage/loader/CloudStorageLoader.scala
+++ b/src/main/scala/com/snowplowanalytics/storage/googlecloudstorage/loader/CloudStorageLoader.scala
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2018-2018 Snowplow Analytics Ltd. All rights reserved.
+ * Copyright (c) 2018-2019 Snowplow Analytics Ltd. All rights reserved.
  *
  * This program is licensed to you under the Apache License Version 2.0,
  * and you may not use this file except in compliance with the Apache License Version 2.0.

--- a/src/main/scala/com/snowplowanalytics/storage/googlecloudstorage/loader/Options.scala
+++ b/src/main/scala/com/snowplowanalytics/storage/googlecloudstorage/loader/Options.scala
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2018-2018 Snowplow Analytics Ltd. All rights reserved.
+ * Copyright (c) 2018-2019 Snowplow Analytics Ltd. All rights reserved.
  *
  * This program is licensed to you under the Apache License Version 2.0,
  * and you may not use this file except in compliance with the Apache License Version 2.0.

--- a/src/main/scala/com/snowplowanalytics/storage/googlecloudstorage/loader/Options.scala
+++ b/src/main/scala/com/snowplowanalytics/storage/googlecloudstorage/loader/Options.scala
@@ -55,8 +55,8 @@ trait Options extends PipelineOptions with StreamingOptions {
   def getCompression: String
   def setCompression(value: String): Unit
 
-  @Description("The maximum number of output shards produced when writing")
-  @Default.Integer(1)
+  @Description("The maximum number of output shards produced when writing. Default: 0 - let runner manage")
+  @Default.Integer(0)
   def getNumShards: Int
   def setNumShards(value: Int): Unit
 }

--- a/src/main/scala/com/snowplowanalytics/storage/googlecloudstorage/loader/WindowedFilenamePolicy.scala
+++ b/src/main/scala/com/snowplowanalytics/storage/googlecloudstorage/loader/WindowedFilenamePolicy.scala
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2018-2018 Snowplow Analytics Ltd. All rights reserved.
+ * Copyright (c) 2018-2019 Snowplow Analytics Ltd. All rights reserved.
  *
  * This program is licensed to you under the Apache License Version 2.0,
  * and you may not use this file except in compliance with the Apache License Version 2.0.

--- a/src/test/scala/com/snowplowanalytics/storage/googlecloudstorage/loader/CloudStorageLoaderSpec.scala
+++ b/src/test/scala/com/snowplowanalytics/storage/googlecloudstorage/loader/CloudStorageLoaderSpec.scala
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2018-2018 Snowplow Analytics Ltd. All rights reserved.
+ * Copyright (c) 2018-2019 Snowplow Analytics Ltd. All rights reserved.
  *
  * This program is licensed to you under the Apache License Version 2.0,
  * and you may not use this file except in compliance with the Apache License Version 2.0.

--- a/src/test/scala/com/snowplowanalytics/storage/googlecloudstorage/loader/CloudStorageLoaderSpec.scala
+++ b/src/test/scala/com/snowplowanalytics/storage/googlecloudstorage/loader/CloudStorageLoaderSpec.scala
@@ -14,6 +14,7 @@
  */
 package com.snowplowanalytics.storage.googlecloudstorage.loader
 
+import com.spotify.scio.io.CustomIO
 import com.spotify.scio.testing._
 
 class CloudStorageLoaderSpec extends PipelineSpec {

--- a/src/test/scala/com/snowplowanalytics/storage/googlecloudstorage/loader/WindowedFilenamePolicySpec.scala
+++ b/src/test/scala/com/snowplowanalytics/storage/googlecloudstorage/loader/WindowedFilenamePolicySpec.scala
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2018-2018 Snowplow Analytics Ltd. All rights reserved.
+ * Copyright (c) 2018-2019 Snowplow Analytics Ltd. All rights reserved.
  *
  * This program is licensed to you under the Apache License Version 2.0,
  * and you may not use this file except in compliance with the Apache License Version 2.0.

--- a/src/test/scala/com/snowplowanalytics/storage/googlecloudstorage/loader/WindowedFilenamePolicySpec.scala
+++ b/src/test/scala/com/snowplowanalytics/storage/googlecloudstorage/loader/WindowedFilenamePolicySpec.scala
@@ -26,7 +26,7 @@ import org.joda.time.DateTime
 import org.mockito.Mockito.when
 import org.scalatest.FreeSpec
 import org.scalatest.Matchers._
-import org.scalatest.mockito.MockitoSugar
+import org.scalatestplus.mockito.MockitoSugar
 
 class WindowedFilenamePolicySpec extends FreeSpec with MockitoSugar {
   object TestOutputFileHints extends OutputFileHints {


### PR DESCRIPTION
This is meant to be a maintenance release fixing a performance issue uncovered in GCP pipelines: #27 

Previously the number of shards has been arbitrarily set to the max number of workers that could have been spawned. This caused unnecessary syncing and degraded performance The change relies on Apache Beam spec that hands sharding management over to the runtime (Dataflow).
At this stage Dataflow job should operate within bounds of the traffic supplied by the collectors at around 1:1 ratio. The spiky characteristics is the result of applied windowing for bunching up writes and the dip before starting up a new node is likely related to running a single worker as a baseline.


Goes along https://github.com/snowplow-devops/terraform-modules/pull/606