### PR TITLE
Release/0.2.0

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -1,3 +1,4 @@
+dist: trusty
 language: scala
 services:
   - docker

--- a/.travis/deploy_template.sh
+++ b/.travis/deploy_template.sh
@@ -15,6 +15,7 @@ if [[ "${tag}" = *"${project_version}" ]]; then
       --tempLocation=gs://sp-hosted-assets/tmp \
       --autoscalingAlgorithm=THROUGHPUT_BASED \
       --numWorkers=1 \
+      --numShards=1 \
       --diskSizeGb=30 \
       --workerMachineType=n1-standard-1"
 else

--- a/CHANGELOG
+++ b/CHANGELOG
@@ -1,3 +1,14 @@
+Version 0.2.0 (2019-12-11)
+--------------------------
+Set default number of shards to be managed by runner (#27)
+Bump mockito to 2.28.2 (#25)
+Bump slf4j to 1.7.29 (#23)
+Bump scalatest to 3.0.8 (#22)
+Bump beam to 2.11.0 (#21)
+Bump scala to 2.12.10 (#20)
+Extend copyright to 2019 (#26)
+Change Travis distribution to Trusty (#29)
+
 Version 0.1.0 (2018-11-23)
 --------------------------
 Initial version

--- a/LICENSE-2.0.txt
+++ b/LICENSE-2.0.txt
@@ -187,7 +187,7 @@
       same "printed page" as the copyright notice for easier
       identification within third-party archives.
 
-   Copyright [2018-2018] [Snowplow Analytics Ltd.]
+   Copyright 2018-2019 Snowplow Analytics Ltd.
 
    Licensed under the Apache License, Version 2.0 (the "License");
    you may not use this file except in compliance with the License.

--- a/README.md
+++ b/README.md
@@ -172,7 +172,7 @@ sbt repl/run
 
 ## Copyright and license
 
-Copyright 2018-2018 Snowplow Analytics Ltd.
+Copyright 2018-2019 Snowplow Analytics Ltd.
 
 Licensed under the [Apache License, Version 2.0][license] (the "License");
 you may not use this software except in compliance with the License.

--- a/README.md
+++ b/README.md
@@ -20,7 +20,8 @@ sbt "runMain com.snowplowanalytics.storage.googlecloudstorage.loader.CloudStorag
   --templateLocation=gs://[BUCKET]/SnowplowGoogleCloudStorageLoaderTemplate \
   --stagingLocation=gs://[BUCKET]/staging \
   --runner=DataflowRunner \
-  --tempLocation=gs://[BUCKET]/tmp"
+  --tempLocation=gs://[BUCKET]/tmp" \
+  --numShards=1
 ```
 
 ### Zip archive
@@ -55,7 +56,7 @@ Here, we provide an example using `gcloud`:
 
 ```bash
 gcloud dataflow jobs run [JOB-NAME] \
-  --gcs-location gs://sp-hosted-assets/4-storage/snowplow-google-cloud-storage-loader/0.1.0/SnowplowGoogleCloudStorageLoaderTemplate-0.1.0 \
+  --gcs-location gs://sp-hosted-assets/4-storage/snowplow-google-cloud-storage-loader/0.2.0/SnowplowGoogleCloudStorageLoaderTemplate-0.2.0 \
   --parameters \
     inputSubscription=projects/[PROJECT]/subscriptions/[SUBSCRIPTION],\
     outputDirectory=gs://[BUCKET]/YYYY/MM/dd/HH/,\ # partitions by date
@@ -111,7 +112,7 @@ A container can be run as follows:
 docker run \
   -v $PWD/config:/snowplow/config \
   -e GOOGLE_APPLICATION_CREDENTIALS=/snowplow/config/credentials.json \ # if running outside GCP
-  snowplow-docker-registry.bintray.io/snowplow/snowplow-google-cloud-storage-loader:0.1.0 \
+  snowplow-docker-registry.bintray.io/snowplow/snowplow-google-cloud-storage-loader:0.2.0 \
   --runner=DataFlowRunner \
   --jobName=[JOB-NAME] \
   --project=[PROJECT] \
@@ -130,14 +131,14 @@ docker run \
 To display the help message:
 
 ```bash
-docker run snowplow-docker-registry.bintray.io/snowplow/snowplow-google-cloud-storage-loader:0.1.0 \
+docker run snowplow-docker-registry.bintray.io/snowplow/snowplow-google-cloud-storage-loader:0.2.0 \
   --help
 ```
 
 To display documentation about Cloud Storage Loader-specific options:
 
 ```bash
-docker run snowplow-docker-registry.bintray.io/snowplow/snowplow-google-cloud-storage-loader:0.1.0 \
+docker run snowplow-docker-registry.bintray.io/snowplow/snowplow-google-cloud-storage-loader:0.2.0 \
   --help=com.snowplowanalytics.storage.googlecloudstorage.loader.Options
 ```
 

--- a/build.sbt
+++ b/build.sbt
@@ -1,8 +1,8 @@
 import sbt._
 import Keys._
 
-val scioVersion = "0.6.1"
 val beamVersion = "2.6.0"
+val scioVersion = "0.7.4"
 val scalaMacrosVersion = "2.1.1"
 val slf4jVersion = "1.7.25"
 val scalatestVersion = "3.0.5"

--- a/build.sbt
+++ b/build.sbt
@@ -6,7 +6,7 @@ val beamVersion = "2.11.0"
 val scalaMacrosVersion = "2.1.1"
 val slf4jVersion = "1.7.29"
 val scalatestVersion = "3.0.8"
-val mockitoVersion = "2.23.0"
+val mockitoVersion = "2.28.2"
 
 lazy val compilerOptions = Seq(
   "-target:jvm-1.8",

--- a/build.sbt
+++ b/build.sbt
@@ -27,7 +27,7 @@ lazy val compilerOptions = Seq(
 lazy val commonSettings = Defaults.coreDefaultSettings ++ Seq(
   organization := "com.snowplowanalytics",
   version := "0.1.0",
-  scalaVersion := "2.12.7",
+  scalaVersion := "2.12.10",
   scalacOptions ++= compilerOptions,
   javacOptions ++= Seq("-source", "1.8", "-target", "1.8")
 )

--- a/build.sbt
+++ b/build.sbt
@@ -26,7 +26,7 @@ lazy val compilerOptions = Seq(
 
 lazy val commonSettings = Defaults.coreDefaultSettings ++ Seq(
   organization := "com.snowplowanalytics",
-  version := "0.1.0",
+  version := "0.2.0",
   scalaVersion := "2.12.10",
   scalacOptions ++= compilerOptions,
   javacOptions ++= Seq("-source", "1.8", "-target", "1.8")

--- a/build.sbt
+++ b/build.sbt
@@ -1,8 +1,8 @@
 import sbt._
 import Keys._
 
-val beamVersion = "2.6.0"
 val scioVersion = "0.7.4"
+val beamVersion = "2.11.0"
 val scalaMacrosVersion = "2.1.1"
 val slf4jVersion = "1.7.25"
 val scalatestVersion = "3.0.5"

--- a/build.sbt
+++ b/build.sbt
@@ -5,7 +5,7 @@ val scioVersion = "0.7.4"
 val beamVersion = "2.11.0"
 val scalaMacrosVersion = "2.1.1"
 val slf4jVersion = "1.7.25"
-val scalatestVersion = "3.0.5"
+val scalatestVersion = "3.0.8"
 val mockitoVersion = "2.23.0"
 
 lazy val compilerOptions = Seq(

--- a/build.sbt
+++ b/build.sbt
@@ -4,7 +4,7 @@ import Keys._
 val scioVersion = "0.7.4"
 val beamVersion = "2.11.0"
 val scalaMacrosVersion = "2.1.1"
-val slf4jVersion = "1.7.25"
+val slf4jVersion = "1.7.29"
 val scalatestVersion = "3.0.8"
 val mockitoVersion = "2.23.0"
 

--- a/src/main/scala/com/snowplowanalytics/storage/googlecloudstorage/loader/CloudStorageLoader.scala
+++ b/src/main/scala/com/snowplowanalytics/storage/googlecloudstorage/loader/CloudStorageLoader.scala
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2018-2018 Snowplow Analytics Ltd. All rights reserved.
+ * Copyright (c) 2018-2019 Snowplow Analytics Ltd. All rights reserved.
  *
  * This program is licensed to you under the Apache License Version 2.0,
  * and you may not use this file except in compliance with the Apache License Version 2.0.

--- a/src/main/scala/com/snowplowanalytics/storage/googlecloudstorage/loader/Options.scala
+++ b/src/main/scala/com/snowplowanalytics/storage/googlecloudstorage/loader/Options.scala
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2018-2018 Snowplow Analytics Ltd. All rights reserved.
+ * Copyright (c) 2018-2019 Snowplow Analytics Ltd. All rights reserved.
  *
  * This program is licensed to you under the Apache License Version 2.0,
  * and you may not use this file except in compliance with the Apache License Version 2.0.

--- a/src/main/scala/com/snowplowanalytics/storage/googlecloudstorage/loader/Options.scala
+++ b/src/main/scala/com/snowplowanalytics/storage/googlecloudstorage/loader/Options.scala
@@ -55,8 +55,8 @@ trait Options extends PipelineOptions with StreamingOptions {
   def getCompression: String
   def setCompression(value: String): Unit
 
-  @Description("The maximum number of output shards produced when writing")
-  @Default.Integer(1)
+  @Description("The maximum number of output shards produced when writing. Default: 0 - let runner manage")
+  @Default.Integer(0)
   def getNumShards: Int
   def setNumShards(value: Int): Unit
 }

--- a/src/main/scala/com/snowplowanalytics/storage/googlecloudstorage/loader/WindowedFilenamePolicy.scala
+++ b/src/main/scala/com/snowplowanalytics/storage/googlecloudstorage/loader/WindowedFilenamePolicy.scala
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2018-2018 Snowplow Analytics Ltd. All rights reserved.
+ * Copyright (c) 2018-2019 Snowplow Analytics Ltd. All rights reserved.
  *
  * This program is licensed to you under the Apache License Version 2.0,
  * and you may not use this file except in compliance with the Apache License Version 2.0.

--- a/src/test/scala/com/snowplowanalytics/storage/googlecloudstorage/loader/CloudStorageLoaderSpec.scala
+++ b/src/test/scala/com/snowplowanalytics/storage/googlecloudstorage/loader/CloudStorageLoaderSpec.scala
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2018-2018 Snowplow Analytics Ltd. All rights reserved.
+ * Copyright (c) 2018-2019 Snowplow Analytics Ltd. All rights reserved.
  *
  * This program is licensed to you under the Apache License Version 2.0,
  * and you may not use this file except in compliance with the Apache License Version 2.0.

--- a/src/test/scala/com/snowplowanalytics/storage/googlecloudstorage/loader/CloudStorageLoaderSpec.scala
+++ b/src/test/scala/com/snowplowanalytics/storage/googlecloudstorage/loader/CloudStorageLoaderSpec.scala
@@ -14,6 +14,7 @@
  */
 package com.snowplowanalytics.storage.googlecloudstorage.loader
 
+import com.spotify.scio.io.CustomIO
 import com.spotify.scio.testing._
 
 class CloudStorageLoaderSpec extends PipelineSpec {

--- a/src/test/scala/com/snowplowanalytics/storage/googlecloudstorage/loader/WindowedFilenamePolicySpec.scala
+++ b/src/test/scala/com/snowplowanalytics/storage/googlecloudstorage/loader/WindowedFilenamePolicySpec.scala
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2018-2018 Snowplow Analytics Ltd. All rights reserved.
+ * Copyright (c) 2018-2019 Snowplow Analytics Ltd. All rights reserved.
  *
  * This program is licensed to you under the Apache License Version 2.0,
  * and you may not use this file except in compliance with the Apache License Version 2.0.

--- a/src/test/scala/com/snowplowanalytics/storage/googlecloudstorage/loader/WindowedFilenamePolicySpec.scala
+++ b/src/test/scala/com/snowplowanalytics/storage/googlecloudstorage/loader/WindowedFilenamePolicySpec.scala
@@ -26,7 +26,7 @@ import org.joda.time.DateTime
 import org.mockito.Mockito.when
 import org.scalatest.FreeSpec
 import org.scalatest.Matchers._
-import org.scalatest.mockito.MockitoSugar
+import org.scalatestplus.mockito.MockitoSugar
 
 class WindowedFilenamePolicySpec extends FreeSpec with MockitoSugar {
   object TestOutputFileHints extends OutputFileHints {


### PR DESCRIPTION
**Basically https://github.com/snowplow-incubator/snowplow-google-cloud-storage-loader/pull/30 with minor version bump (instead of patch) and comments applied**

- [x] Update release date in changelog

This is meant to be a maintenance release fixing a performance issue uncovered in GCP pipelines: #27

Previously the number of shards has been arbitrarily set to the max number of workers that could have been spawned. This caused unnecessary syncing and degraded performance The change relies on Apache Beam spec that hands sharding management over to the runtime (Dataflow).
At this stage Dataflow job should operate within bounds of the traffic supplied by the collectors at around 1:1 ratio. The spiky characteristics is the result of applied windowing for bunching up writes and the dip before starting up a new node is likely related to running a single worker as a baseline.

Goes along snowplow-devops/terraform-modules#606