### PR TITLE
Updating zone & region

### DIFF
--- a/README.md
+++ b/README.md
@@ -45,7 +45,8 @@ docker run \
   --jobName=[JOB-NAME] \
   --project=[PROJECT] \
   --streaming=true \
-  --zone=[ZONE] \
+  --workerZone=[ZONE] \
+  --region=[REGION] \ # where to place the bucket for staging files
   --inputSubscription=projects/[PROJECT]/subscriptions/[SUBSCRIPTION] \
   --outputDirectory=gs://[BUCKET] \
   --outputFilenamePrefix=output \ # optional


### PR DESCRIPTION
zone is apparently being replaced by workerZone, and region is still needed if one needs a bucket to place temp staging files.