### PR TITLE
Modernize to Java 21 and clear application CVEs

### DIFF
--- a/.github/workflows/deploy.yml
+++ b/.github/workflows/deploy.yml
@@ -17,6 +17,8 @@ jobs:
         with:
           distribution: temurin
           java-version: 21
+      - name: Set up sbt
+        uses: sbt/setup-sbt@v1
 
       - name: Build local image, which is needed to run Snyk
         run: sbt "project distroless" docker:publishLocal
@@ -40,6 +42,8 @@ jobs:
         with:
           distribution: temurin
           java-version: 21
+      - name: Set up sbt
+        uses: sbt/setup-sbt@v1
 
       - name: Get current version
         id: ver
@@ -113,6 +117,8 @@ jobs:
         with:
           distribution: temurin
           java-version: 21
+      - name: Set up sbt
+        uses: sbt/setup-sbt@v1
       - name: Authorize gcp sdk
         id: auth
         uses: 'google-github-actions/auth@v0'
@@ -149,6 +155,8 @@ jobs:
         with:
           distribution: temurin
           java-version: 21
+      - name: Set up sbt
+        uses: sbt/setup-sbt@v1
       - name: Get current version
         id: ver
         run: echo "::set-output name=tag::${GITHUB_REF#refs/tags/}"

--- a/.github/workflows/deploy.yml
+++ b/.github/workflows/deploy.yml
@@ -61,7 +61,7 @@ jobs:
         with:
           images: snowplow/snowplow-google-cloud-storage-loader
           tags: |
-            type=raw,value=latest,enable=${{ !contains(steps.ver.outputs.tag, 'rc') }}
+            type=raw,value=latest,enable=${{ !contains(steps.ver.outputs.tag, 'rc') && !contains(steps.ver.outputs.tag, 'dev') }}
             type=raw,value=${{ steps.ver.outputs.tag }}
           flavor: |
             latest=false
@@ -72,7 +72,7 @@ jobs:
         with:
           images: snowplow/snowplow-google-cloud-storage-loader
           tags: |
-            type=raw,value=latest-distroless,enable=${{ !contains(steps.ver.outputs.tag, 'rc') }}
+            type=raw,value=latest-distroless,enable=${{ !contains(steps.ver.outputs.tag, 'rc') && !contains(steps.ver.outputs.tag, 'dev') }}
             type=raw,value=${{ steps.ver.outputs.tag }}-distroless
           flavor: |
             latest=false

--- a/.github/workflows/deploy.yml
+++ b/.github/workflows/deploy.yml
@@ -10,12 +10,13 @@ jobs:
     if: ${{ !contains(github.ref, 'rc') }}
     runs-on: ubuntu-latest
     steps:
-      - uses: actions/checkout@v2
-      - uses: coursier/cache-action@v3
+      - uses: actions/checkout@v4
+      - uses: coursier/cache-action@v6
       - name: Set up JDK
-        uses: actions/setup-java@v1
+        uses: actions/setup-java@v4
         with:
-          java-version: 8
+          distribution: temurin
+          java-version: 21
 
       - name: Build local image, which is needed to run Snyk
         run: sbt "project distroless" docker:publishLocal
@@ -32,12 +33,13 @@ jobs:
   deploy_docker:
     runs-on: ubuntu-latest
     steps:
-      - uses: actions/checkout@v2
-      - uses: coursier/cache-action@v3
+      - uses: actions/checkout@v4
+      - uses: coursier/cache-action@v6
       - name: Set up JDK
-        uses: actions/setup-java@v1
+        uses: actions/setup-java@v4
         with:
-          java-version: 8
+          distribution: temurin
+          java-version: 21
 
       - name: Get current version
         id: ver
@@ -104,12 +106,13 @@ jobs:
   deploy_template:
     runs-on: ubuntu-latest
     steps:
-      - uses: actions/checkout@v2
-      - uses: coursier/cache-action@v3
+      - uses: actions/checkout@v4
+      - uses: coursier/cache-action@v6
       - name: Set up JDK
-        uses: actions/setup-java@v1
+        uses: actions/setup-java@v4
         with:
-          java-version: 8
+          distribution: temurin
+          java-version: 21
       - name: Authorize gcp sdk
         id: auth
         uses: 'google-github-actions/auth@v0'
@@ -139,12 +142,13 @@ jobs:
   deploy_github:
     runs-on: ubuntu-latest
     steps:
-      - uses: actions/checkout@v2
-      - uses: coursier/cache-action@v3
+      - uses: actions/checkout@v4
+      - uses: coursier/cache-action@v6
       - name: Set up JDK
-        uses: actions/setup-java@v1
+        uses: actions/setup-java@v4
         with:
-          java-version: 8
+          distribution: temurin
+          java-version: 21
       - name: Get current version
         id: ver
         run: echo "::set-output name=tag::${GITHUB_REF#refs/tags/}"

--- a/.github/workflows/lacework.yml
+++ b/.github/workflows/lacework.yml
@@ -16,6 +16,8 @@ jobs:
         with:
           distribution: temurin
           java-version: 21
+      - name: Set up sbt
+        uses: sbt/setup-sbt@v1
       - name: Get current version
         id: ver
         run: echo "::set-output name=tag::${GITHUB_REF#refs/tags/}"

--- a/.github/workflows/lacework.yml
+++ b/.github/workflows/lacework.yml
@@ -9,12 +9,13 @@ jobs:
   scan:
     runs-on: ubuntu-latest
     steps:
-      - uses: actions/checkout@v2
-      - uses: coursier/cache-action@v3
+      - uses: actions/checkout@v4
+      - uses: coursier/cache-action@v6
       - name: Set up JDK
-        uses: actions/setup-java@v1
+        uses: actions/setup-java@v4
         with:
-          java-version: 8
+          distribution: temurin
+          java-version: 21
       - name: Get current version
         id: ver
         run: echo "::set-output name=tag::${GITHUB_REF#refs/tags/}"

--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -13,5 +13,7 @@ jobs:
         with:
           distribution: temurin
           java-version: 21
+      - name: Set up sbt
+        uses: sbt/setup-sbt@v1
       - name: Run tests
         run: sbt test

--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -6,11 +6,12 @@ jobs:
   test:
     runs-on: ubuntu-latest
     steps:
-      - uses: actions/checkout@v2
-      - uses: coursier/cache-action@v3
+      - uses: actions/checkout@v4
+      - uses: coursier/cache-action@v6
       - name: Set up JDK
-        uses: actions/setup-java@v1
+        uses: actions/setup-java@v4
         with:
-          java-version: 8
+          distribution: temurin
+          java-version: 21
       - name: Run tests
         run: sbt test

--- a/project/BuildSettings.scala
+++ b/project/BuildSettings.scala
@@ -39,7 +39,7 @@ object BuildSettings {
 
   lazy val commonSettings = Defaults.coreDefaultSettings ++ Seq(
     organization := "com.snowplowanalytics",
-    scalaVersion := "2.12.10",
+    scalaVersion := "2.12.21",
     scalacOptions ++= compilerOptions,
     javacOptions ++= Seq("-source", "1.8", "-target", "1.8")
   )
@@ -58,14 +58,14 @@ object BuildSettings {
         Dependencies.Libraries.igluCore,
         Dependencies.Libraries.slf4j,
         Dependencies.Libraries.jackson,
-        Dependencies.Libraries.avro,
-        Dependencies.Libraries.protobuf,
         Dependencies.Libraries.nettyCodec,
-        Dependencies.Libraries.kaml,
+        Dependencies.Libraries.nettyProxy,
+        Dependencies.Libraries.opentelemetry,
         Dependencies.Libraries.scioTest,
         Dependencies.Libraries.scalatest,
         Dependencies.Libraries.mockito
       ),
+      dependencyOverrides ++= Dependencies.wireOverrides,
       resolvers += "Confluent Repository" at "https://packages.confluent.io/maven/"
     )
 

--- a/project/Dependencies.scala
+++ b/project/Dependencies.scala
@@ -18,21 +18,30 @@ import sbt._
 object Dependencies {
 
   object V {
-    val scio          = "0.14.8"
-    val beam          = "2.60.0"
+    val scio          = "0.15.7"
+    val beam          = "2.74.0"
     val scalaMacros   = "2.1.1"
     val slf4j         = "1.7.36"
     val scalatest     = "3.2.10"
     val scalatestPlus = "3.1.2.0"
     val circe         = "0.14.3"
     val igluCore      = "1.1.3"
-    val jackson       = "2.17.2" // An override, to mitigate a CVE
-    val nettyCodec    = "4.1.108.Final" // An override, to mitigate a CVE
-    val avro          = "1.11.4" // An override, to mitigate a CVE
-    val protobuf      = "3.25.5" // An override, to mitigate a CVE
-    val kaml          = "0.53.0" // An override, to mitigate a CVE
+    val jackson       = "2.18.7" // An override, to mitigate a CVE
+    val nettyCodec    = "4.1.135.Final" // An override, to mitigate a CVE
+    val opentelemetry = "1.62.0" // An override, to mitigate a CVE
+    val wire          = "6.3.0"  // An override, to mitigate a CVE (wire-runtime)
     val paradise      = "2.1.1"
   }
+
+  // wire-runtime / wire-runtime-jvm (pulled transitively via Beam's protobuf
+  // extension -> apicurio) carry CVEs only fixed in the 6.x line. wire requires
+  // a single version across its modules, so every wire artifact in the graph is
+  // forced to V.wire. wire-grpc-server / wire-grpc-server-generator have no 6.x
+  // release and are no longer pulled once wire-grpc-client is at 6.x.
+  val wireOverrides = Seq(
+    "wire-compiler", "wire-grpc-client-jvm", "wire-java-generator", "wire-kotlin-generator",
+    "wire-runtime", "wire-runtime-jvm", "wire-schema", "wire-schema-jvm", "wire-swift-generator"
+  ).map(a => "com.squareup.wire" % a % V.wire)
 
   object Libraries {
     val beam        = "org.apache.beam"              % "beam-runners-google-cloud-dataflow-java" % V.beam
@@ -43,10 +52,9 @@ object Dependencies {
     val slf4j       = "org.slf4j"                    %  "slf4j-simple"                           % V.slf4j
     val paradise    = "org.scalamacros"              %  "paradise"                               % V.paradise
     val jackson     = "com.fasterxml.jackson.module" %% "jackson-module-scala"                   % V.jackson
-    val avro        = "org.apache.avro"              %  "avro"                                   % V.avro
-    val protobuf    = "com.google.protobuf"          %  "protobuf-java-util"                     % V.protobuf
     val nettyCodec  = "io.netty"                     %  "netty-codec-http2"                      % V.nettyCodec
-    val kaml        = "com.charleskorn.kaml"         %  "kaml"                                   % V.kaml
+    val nettyProxy  = "io.netty"                     %  "netty-handler-proxy"                    % V.nettyCodec
+    val opentelemetry  = "io.opentelemetry"          %  "opentelemetry-api"                      % V.opentelemetry
     val reflect     = "org.scala-lang"               %  "scala-reflect"
 
     // Test

--- a/project/build.properties
+++ b/project/build.properties
@@ -1,1 +1,1 @@
-sbt.version=1.5.6
+sbt.version=1.12.13

--- a/project/plugins.sbt
+++ b/project/plugins.sbt
@@ -1,3 +1,7 @@
+// scalastyle (1.0.0, unmaintained) pulls scala-xml 1.0.6 while the newer
+// sbt-native-packager pulls 2.x; allow the newer to win during plugin resolution.
+ThisBuild / libraryDependencySchemes += "org.scala-lang.modules" %% "scala-xml" % VersionScheme.Always
+
 addSbtPlugin("org.scalastyle" %% "scalastyle-sbt-plugin" % "1.0.0")
 addSbtPlugin("com.dwijnand" % "sbt-dynver" % "4.1.1")
-addSbtPlugin("com.snowplowanalytics" % "sbt-snowplow-release" % "0.3.2")
+addSbtPlugin("com.snowplowanalytics" % "sbt-snowplow-release" % "0.7.0")


### PR DESCRIPTION
## Summary

Modernizes the toolchain/framework so the published distroless image runs on **Java 21 / Debian 13** and carries **no fixable application-dependency CVEs**. Addresses the customer (Motorway) Wiz/Snyk findings against `0.5.6-distroless`.

**Image application CVEs: 37 → 0.** Tests pass (10/10) and the project compiles on Java 21.

## Toolchain / framework
- sbt `1.5.6` → `1.12.13`
- sbt-snowplow-release `0.3.2` → `0.7.0` (distroless base `java11-debian11` → **`java21-debian13`**)
- Scala `2.12.10` → `2.12.21`
- Scio `0.14.8` → `0.15.7`, Beam `2.60.0` → `2.74.0`

The Beam/Scio bump is the **parent fix** for most CVEs — it ships grpc `1.80.0`, commons-lang3 `3.18.0`, avro `1.12.0`, protobuf `4.33.2` natively.

## Dependency overrides — net reduction
**Removed (made redundant by Beam 2.74):**
- `avro 1.11.4` (Beam ships 1.12.0), `protobuf 3.25.5` (Beam ships 4.33.2)
- `kaml 0.53.0` (on Beam 2.74 kaml arrives only as `kaml-jvm 0.104.0` via wire; the plain-`kaml` override was self-referential)
- Did **not** need to add grpc or commons-lang3 overrides

**Still needed (Beam 2.74's transitive is below the fix):**
| Override | Beam 2.74 pulls | Fix needs |
|---|---|---|
| `jackson 2.17.2 → 2.18.7` | 2.18.3 | 2.18.7 (also required for module-scala/databind compat — build fails otherwise) |
| `netty 4.1.108 → 4.1.135` (+ handler-proxy) | 4.1.130 | 4.1.135 (1 critical + highs) |
| `opentelemetry-api 1.62.0` (new) | 1.56.0 | 1.62.0 |
| `wire 6.3.0` (new, whole-family override) | 4.8.0/4.9.3 (via apicurio milestone) | 6.3.0 |

Also adds a `scala-xml` version scheme so the unmaintained scalastyle plugin co-exists with the newer sbt-native-packager during plugin resolution.

## Residual
- `expat` (1 high + 1 medium) in the Debian 13 base — `fixedIn` is empty (no Debian fix released yet). Base image is already on the latest plugin (`0.7.0`); not addressable via dependencies. Same category as ST-371. The previous glibc finding is gone.

## ⚠️ Before release
The 10 unit tests validate row-type logic only — they do **not** exercise the Beam/Dataflow runtime on Java 21. Beam 2.74 officially supports Java 21, but **run an actual Dataflow job from this image before publishing**, since Java 17+ runtimes typically need `--add-opens` flags for Beam's reflection.

🤖 Generated with [Claude Code](https://claude.com/claude-code)


ref: https://snplow.atlassian.net/browse/PDP-2733