### PR TITLE
Prepare for 0.5.7 release

### DIFF
--- a/.github/workflows/deploy.yml
+++ b/.github/workflows/deploy.yml
@@ -10,12 +10,15 @@ jobs:
     if: ${{ !contains(github.ref, 'rc') }}
     runs-on: ubuntu-latest
     steps:
-      - uses: actions/checkout@v2
-      - uses: coursier/cache-action@v3
+      - uses: actions/checkout@v4
+      - uses: coursier/cache-action@v6
       - name: Set up JDK
-        uses: actions/setup-java@v1
+        uses: actions/setup-java@v4
         with:
-          java-version: 8
+          distribution: temurin
+          java-version: 21
+      - name: Set up sbt
+        uses: sbt/setup-sbt@v1
 
       - name: Build local image, which is needed to run Snyk
         run: sbt "project distroless" docker:publishLocal
@@ -32,12 +35,15 @@ jobs:
   deploy_docker:
     runs-on: ubuntu-latest
     steps:
-      - uses: actions/checkout@v2
-      - uses: coursier/cache-action@v3
+      - uses: actions/checkout@v4
+      - uses: coursier/cache-action@v6
       - name: Set up JDK
-        uses: actions/setup-java@v1
+        uses: actions/setup-java@v4
         with:
-          java-version: 8
+          distribution: temurin
+          java-version: 21
+      - name: Set up sbt
+        uses: sbt/setup-sbt@v1
 
       - name: Get current version
         id: ver
@@ -55,7 +61,7 @@ jobs:
         with:
           images: snowplow/snowplow-google-cloud-storage-loader
           tags: |
-            type=raw,value=latest,enable=${{ !contains(steps.ver.outputs.tag, 'rc') }}
+            type=raw,value=latest,enable=${{ !contains(steps.ver.outputs.tag, 'rc') && !contains(steps.ver.outputs.tag, 'dev') }}
             type=raw,value=${{ steps.ver.outputs.tag }}
           flavor: |
             latest=false
@@ -66,7 +72,7 @@ jobs:
         with:
           images: snowplow/snowplow-google-cloud-storage-loader
           tags: |
-            type=raw,value=latest-distroless,enable=${{ !contains(steps.ver.outputs.tag, 'rc') }}
+            type=raw,value=latest-distroless,enable=${{ !contains(steps.ver.outputs.tag, 'rc') && !contains(steps.ver.outputs.tag, 'dev') }}
             type=raw,value=${{ steps.ver.outputs.tag }}-distroless
           flavor: |
             latest=false
@@ -104,12 +110,15 @@ jobs:
   deploy_template:
     runs-on: ubuntu-latest
     steps:
-      - uses: actions/checkout@v2
-      - uses: coursier/cache-action@v3
+      - uses: actions/checkout@v4
+      - uses: coursier/cache-action@v6
       - name: Set up JDK
-        uses: actions/setup-java@v1
+        uses: actions/setup-java@v4
         with:
-          java-version: 8
+          distribution: temurin
+          java-version: 21
+      - name: Set up sbt
+        uses: sbt/setup-sbt@v1
       - name: Authorize gcp sdk
         id: auth
         uses: 'google-github-actions/auth@v0'
@@ -139,12 +148,15 @@ jobs:
   deploy_github:
     runs-on: ubuntu-latest
     steps:
-      - uses: actions/checkout@v2
-      - uses: coursier/cache-action@v3
+      - uses: actions/checkout@v4
+      - uses: coursier/cache-action@v6
       - name: Set up JDK
-        uses: actions/setup-java@v1
+        uses: actions/setup-java@v4
         with:
-          java-version: 8
+          distribution: temurin
+          java-version: 21
+      - name: Set up sbt
+        uses: sbt/setup-sbt@v1
       - name: Get current version
         id: ver
         run: echo "::set-output name=tag::${GITHUB_REF#refs/tags/}"

--- a/.github/workflows/lacework.yml
+++ b/.github/workflows/lacework.yml
@@ -9,12 +9,15 @@ jobs:
   scan:
     runs-on: ubuntu-latest
     steps:
-      - uses: actions/checkout@v2
-      - uses: coursier/cache-action@v3
+      - uses: actions/checkout@v4
+      - uses: coursier/cache-action@v6
       - name: Set up JDK
-        uses: actions/setup-java@v1
+        uses: actions/setup-java@v4
         with:
-          java-version: 8
+          distribution: temurin
+          java-version: 21
+      - name: Set up sbt
+        uses: sbt/setup-sbt@v1
       - name: Get current version
         id: ver
         run: echo "::set-output name=tag::${GITHUB_REF#refs/tags/}"

--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -6,11 +6,14 @@ jobs:
   test:
     runs-on: ubuntu-latest
     steps:
-      - uses: actions/checkout@v2
-      - uses: coursier/cache-action@v3
+      - uses: actions/checkout@v4
+      - uses: coursier/cache-action@v6
       - name: Set up JDK
-        uses: actions/setup-java@v1
+        uses: actions/setup-java@v4
         with:
-          java-version: 8
+          distribution: temurin
+          java-version: 21
+      - name: Set up sbt
+        uses: sbt/setup-sbt@v1
       - name: Run tests
         run: sbt test

--- a/CHANGELOG
+++ b/CHANGELOG
@@ -1,3 +1,7 @@
+Version 0.5.7 (2026-06-22)
+--------------------------
+Modernize to Java 21 (#99)
+
 Version 0.5.6 (2024-11-05)
 --------------------------
 Upgrade dependencies

--- a/README.md
+++ b/README.md
@@ -40,7 +40,7 @@ A container can be run as follows:
 docker run \
   -v $PWD/config:/snowplow/config \
   -e GOOGLE_APPLICATION_CREDENTIALS=/snowplow/config/credentials.json \ # if running outside GCP
-  snowplow/snowplow-google-cloud-storage-loader:0.5.6 \
+  snowplow/snowplow-google-cloud-storage-loader:0.5.7 \
   --runner=DataFlowRunner \
   --jobName=[JOB-NAME] \
   --project=[PROJECT] \
@@ -62,14 +62,14 @@ docker run \
 To display the help message:
 
 ```bash
-docker run snowplow/snowplow-google-cloud-storage-loader:0.5.6 \
+docker run snowplow/snowplow-google-cloud-storage-loader:0.5.7 \
   --help
 ```
 
 To display documentation about Cloud Storage Loader-specific options:
 
 ```bash
-docker run snowplow/snowplow-google-cloud-storage-loader:0.5.6 \
+docker run snowplow/snowplow-google-cloud-storage-loader:0.5.7 \
   --help=com.snowplowanalytics.storage.googlecloudstorage.loader.Options
 ```
 

--- a/project/BuildSettings.scala
+++ b/project/BuildSettings.scala
@@ -39,7 +39,7 @@ object BuildSettings {
 
   lazy val commonSettings = Defaults.coreDefaultSettings ++ Seq(
     organization := "com.snowplowanalytics",
-    scalaVersion := "2.12.10",
+    scalaVersion := "2.12.21",
     scalacOptions ++= compilerOptions,
     javacOptions ++= Seq("-source", "1.8", "-target", "1.8")
   )
@@ -58,14 +58,14 @@ object BuildSettings {
         Dependencies.Libraries.igluCore,
         Dependencies.Libraries.slf4j,
         Dependencies.Libraries.jackson,
-        Dependencies.Libraries.avro,
-        Dependencies.Libraries.protobuf,
         Dependencies.Libraries.nettyCodec,
-        Dependencies.Libraries.kaml,
+        Dependencies.Libraries.nettyProxy,
+        Dependencies.Libraries.opentelemetry,
         Dependencies.Libraries.scioTest,
         Dependencies.Libraries.scalatest,
         Dependencies.Libraries.mockito
       ),
+      dependencyOverrides ++= Dependencies.wireOverrides,
       resolvers += "Confluent Repository" at "https://packages.confluent.io/maven/"
     )
 

--- a/project/Dependencies.scala
+++ b/project/Dependencies.scala
@@ -18,21 +18,30 @@ import sbt._
 object Dependencies {
 
   object V {
-    val scio          = "0.14.8"
-    val beam          = "2.60.0"
+    val scio          = "0.15.7"
+    val beam          = "2.74.0"
     val scalaMacros   = "2.1.1"
     val slf4j         = "1.7.36"
     val scalatest     = "3.2.10"
     val scalatestPlus = "3.1.2.0"
     val circe         = "0.14.3"
     val igluCore      = "1.1.3"
-    val jackson       = "2.17.2" // An override, to mitigate a CVE
-    val nettyCodec    = "4.1.108.Final" // An override, to mitigate a CVE
-    val avro          = "1.11.4" // An override, to mitigate a CVE
-    val protobuf      = "3.25.5" // An override, to mitigate a CVE
-    val kaml          = "0.53.0" // An override, to mitigate a CVE
+    val jackson       = "2.18.7" // An override, to mitigate a CVE
+    val nettyCodec    = "4.1.135.Final" // An override, to mitigate a CVE
+    val opentelemetry = "1.62.0" // An override, to mitigate a CVE
+    val wire          = "6.3.0"  // An override, to mitigate a CVE (wire-runtime)
     val paradise      = "2.1.1"
   }
+
+  // wire-runtime / wire-runtime-jvm (pulled transitively via Beam's protobuf
+  // extension -> apicurio) carry CVEs only fixed in the 6.x line. wire requires
+  // a single version across its modules, so every wire artifact in the graph is
+  // forced to V.wire. wire-grpc-server / wire-grpc-server-generator have no 6.x
+  // release and are no longer pulled once wire-grpc-client is at 6.x.
+  val wireOverrides = Seq(
+    "wire-compiler", "wire-grpc-client-jvm", "wire-java-generator", "wire-kotlin-generator",
+    "wire-runtime", "wire-runtime-jvm", "wire-schema", "wire-schema-jvm", "wire-swift-generator"
+  ).map(a => "com.squareup.wire" % a % V.wire)
 
   object Libraries {
     val beam        = "org.apache.beam"              % "beam-runners-google-cloud-dataflow-java" % V.beam
@@ -43,10 +52,9 @@ object Dependencies {
     val slf4j       = "org.slf4j"                    %  "slf4j-simple"                           % V.slf4j
     val paradise    = "org.scalamacros"              %  "paradise"                               % V.paradise
     val jackson     = "com.fasterxml.jackson.module" %% "jackson-module-scala"                   % V.jackson
-    val avro        = "org.apache.avro"              %  "avro"                                   % V.avro
-    val protobuf    = "com.google.protobuf"          %  "protobuf-java-util"                     % V.protobuf
     val nettyCodec  = "io.netty"                     %  "netty-codec-http2"                      % V.nettyCodec
-    val kaml        = "com.charleskorn.kaml"         %  "kaml"                                   % V.kaml
+    val nettyProxy  = "io.netty"                     %  "netty-handler-proxy"                    % V.nettyCodec
+    val opentelemetry  = "io.opentelemetry"          %  "opentelemetry-api"                      % V.opentelemetry
     val reflect     = "org.scala-lang"               %  "scala-reflect"
 
     // Test

--- a/project/build.properties
+++ b/project/build.properties
@@ -1,1 +1,1 @@
-sbt.version=1.5.6
+sbt.version=1.12.13

--- a/project/plugins.sbt
+++ b/project/plugins.sbt
@@ -1,3 +1,7 @@
+// scalastyle (1.0.0, unmaintained) pulls scala-xml 1.0.6 while the newer
+// sbt-native-packager pulls 2.x; allow the newer to win during plugin resolution.
+ThisBuild / libraryDependencySchemes += "org.scala-lang.modules" %% "scala-xml" % VersionScheme.Always
+
 addSbtPlugin("org.scalastyle" %% "scalastyle-sbt-plugin" % "1.0.0")
 addSbtPlugin("com.dwijnand" % "sbt-dynver" % "4.1.1")
-addSbtPlugin("com.snowplowanalytics" % "sbt-snowplow-release" % "0.3.2")
+addSbtPlugin("com.snowplowanalytics" % "sbt-snowplow-release" % "0.7.0")


### PR DESCRIPTION
Release prep for **0.5.7**.

## Changes since 0.5.6
- Modernize to Java 21 (#99) — sbt 1.12.13, Scala 2.12.21, Scio 0.15.7, Beam 2.74.0, distroless `java21-debian13` base; clears all fixable application-dependency CVEs (37 → 0).

## This PR
- `CHANGELOG`: add the `Version 0.5.7 (2026-06-22)` block
- `README.md`: bump image references `0.5.6` → `0.5.7`

## Validation
`0.5.7-dev1` was run on Dataflow (dev1 env) and came up healthy — SDK 2.74.0, Running, stable watermark lag, no Java 21 `add-opens` issues (see #99). Residual: an `expat` finding in the Debian 13 base with no upstream fix available (base-image, not dependency-addressable).

After merge: tag `0.5.7` to publish the release (will correctly move `latest`).

ref: https://snplow.atlassian.net/browse/CSTMR-2106